### PR TITLE
Small script to update the version in gemspecs on release

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -42,23 +42,23 @@ $ bundle exec rspec spec
 $ open coverage/index.html
 ```
 
-## Publish a new gem
+## Publish gems
 
 ```shell
 git checkout master && git pull --rebase
-VERSION=v0.0.x
+export VERSION=v0.0.x
 
-# update version in riverqueue.gemspec!!
+ruby scripts/update_gemspec_version.rb riverqueue.gemspec > riverqueue.gemspec
 gem build riverqueue.gemspec
-gem push riverqueue-$VERSION.gem
+gem push riverqueue-${"${VERSION}"/v/}.gem
 
-# update version in drivers/riverqueue-activerecord.gemspec!!
+ruby scripts/update_gemspec_version.rb drivers/riverqueue-activerecord.gemspec > drivers/riverqueue-activerecord.gemspec
 pushd drivers/riverqueue-activerecord && gem build riverqueue-activerecord.gemspec && popd
-pushd drivers/riverqueue-activerecord && gem push riverqueue-activerecord-$VERSION.gem && popd
+pushd drivers/riverqueue-activerecord && gem push riverqueue-activerecord-${"${VERSION}"/v/}.gem && popd
 
-# update version in drivers/riverqueue-sequel.gemspec!!
+ruby scripts/update_gemspec_version.rb drivers/riverqueue-sequel.gemspec > drivers/riverqueue-sequel.gemspec
 pushd drivers/riverqueue-sequel && gem build riverqueue-sequel.gemspec && popd
-pushd drivers/riverqueue-sequel && gem push riverqueue-sequel-$VERSION.gem && popd
+pushd drivers/riverqueue-sequel && gem push riverqueue-sequel-${"${VERSION}"/v/}.gem && popd
 
 git tag $VERSION
 git push --tags

--- a/scripts/update_gemspec_version.rb
+++ b/scripts/update_gemspec_version.rb
@@ -1,0 +1,15 @@
+#
+# Updates the version in a gemspec file since doing it from the shell is a total
+# pain.
+#
+
+file = ARGV[0] || abort("failure: need one argument, which is a gemspec filename")
+version = ENV["VERSION"] || abort("failure: need VERSION")
+
+file_data = File.read(file)
+
+updated_file_data = file_data.gsub(%r{^(\W+)s\.version = "0.2.0"$}, %(\\1s.version = "#{version}"))
+
+abort("failure: nothing changed in file") if file_data == updated_file_data
+
+puts updated_file_data


### PR DESCRIPTION
Add a small script to update the version in gemspecs on release so that
the release instructions don't have to involved manually opening up a
file.

The release on this one is complicated enough between the multiple gems
that it should probably get a full script, but that'll be its own rabbit
hole in testing. This should hold us over.