### PR TITLE
Implement `#insert_many` for batch job insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-04-27
+
+### Added
+
+- Implement #insert_many for batch job insertion. [PR #5](https://github.com/riverqueue/riverqueue-ruby/pull/5).
+
 ## [0.1.0] - 2024-04-25
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,8 @@ standardrb:
 steep:
 	bundle exec steep check
 
+.PHONY: test
+test: spec
+
 .PHONY: type-check
 type-check: steep

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ class SortArgs
 end
 
 insert_res = client.insert(SimpleArgs.new(strings: ["whale", "tiger", "bear"]))
+insert_res.job # inserted job row
 ```
 
 Job args should:
@@ -67,6 +68,26 @@ insert_res = client.insert(
 insert_res = client.insert(River::JobArgsHash.new("hash_kind", {
     job_num: 1
 }))
+```
+
+### Bulk inserting jobs
+
+Use `#insert_many` to bulk insert jobs as a single operation for improved efficiency:
+
+```ruby
+num_inserted = client.insert_many([
+  SimpleArgs.new(job_num: 1),
+  SimpleArgs.new(job_num: 2)
+])
+```
+
+Or with `InsertManyParams`, which may include insertion options:
+
+```ruby
+num_inserted = client.insert_many([
+  River::InsertManyParams.new(SimpleArgs.new(job_num: 1), insert_opts: InsertOpts.new(max_attempts: 5)),
+  River::InsertManyParams.new(SimpleArgs.new(job_num: 2), insert_opts: InsertOpts.new(queue: "high_priority"))
+])
 ```
 
 ## Drivers

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,6 +44,8 @@ $ open coverage/index.html
 
 ## Publish gems
 
+Update `CHANGELOG.md` to include the new version and open a pull request with the changes.
+
 ```shell
 git checkout master && git pull --rebase
 export VERSION=v0.0.x

--- a/drivers/riverqueue-activerecord/lib/driver.rb
+++ b/drivers/riverqueue-activerecord/lib/driver.rb
@@ -22,66 +22,72 @@ module River::Driver
             return false if method_name == "errors"
             super
           end
+
+          # See comment above, but since we force allowed `errors` as an
+          # attribute name, ActiveRecord would otherwise fail to save a row as
+          # it checked for its own `errors` hash and finding no values.
+          def errors = {}
         end)
       end
     end
 
     def insert(insert_params)
+      to_job_row(RiverJob.create(insert_params_to_hash(insert_params)))
+    end
+
+    def insert_many(insert_params_many)
+      RiverJob.insert_all(insert_params_many.map { |p| insert_params_to_hash(p) })
+      insert_params_many.count
+    end
+
+    private def insert_params_to_hash(insert_params)
       # the call to `#compact` is important so that we remove nils and table
       # default values get picked up instead
-      to_job_row(
-        RiverJob.insert(
-          {
-            args: insert_params.encoded_args,
-            kind: insert_params.kind,
-            max_attempts: insert_params.max_attempts,
-            priority: insert_params.priority,
-            queue: insert_params.queue,
-            state: insert_params.state,
-            scheduled_at: insert_params.scheduled_at,
-            tags: insert_params.tags
-          }.compact,
-          returning: Arel.sql("*")
-        ).first
-      )
+      {
+        args: insert_params.encoded_args,
+        kind: insert_params.kind,
+        max_attempts: insert_params.max_attempts,
+        priority: insert_params.priority,
+        queue: insert_params.queue,
+        state: insert_params.state,
+        scheduled_at: insert_params.scheduled_at,
+        tags: insert_params.tags
+      }.compact
     end
 
     # Type type injected to this method is not a `RiverJob`, but rather a raw
     # hash with stringified keys because we're inserting with the Arel framework
     # directly rather than generating a record from a model.
-    private def to_job_row(raw_job)
-      deserialize = ->(field) do
-        RiverJob._default_attributes[field].type.deserialize(raw_job[field])
-      end
-
-      # Errors is `jsonb[]` so the subtype here will decode `jsonb`.
-      errors_subtype = RiverJob._default_attributes["errors"].type.subtype
+    private def to_job_row(river_job)
+      # needs to be accessed through values because `errors` is shadowed by both
+      # ActiveRecord and the patch above
+      errors = river_job.attributes["errors"]
 
       River::JobRow.new(
-        id: deserialize.call("id"),
-        args: deserialize.call("args").yield_self { |a| a ? JSON.parse(a) : nil },
-        attempt: deserialize.call("attempt"),
-        attempted_at: deserialize.call("attempted_at"),
-        attempted_by: deserialize.call("attempted_by"),
-        created_at: deserialize.call("created_at"),
-        errors: deserialize.call("errors")&.map do |e|
-          deserialized_error = errors_subtype.deserialize(e)
+        id: river_job.id,
+        args: river_job.args ? JSON.parse(river_job.args) : nil,
+        attempt: river_job.attempt,
+        attempted_at: river_job.attempted_at,
+        attempted_by: river_job.attempted_by,
+        created_at: river_job.created_at,
+        errors: errors&.map { |e|
+          deserialized_error = JSON.parse(e, symbolize_names: true)
 
           River::AttemptError.new(
-            at: Time.parse(deserialized_error["at"]),
-            attempt: deserialized_error["attempt"],
-            error: deserialized_error["error"],
-            trace: deserialized_error["trace"]
+            at: Time.parse(deserialized_error[:at]),
+            attempt: deserialized_error[:attempt],
+            error: deserialized_error[:error],
+            trace: deserialized_error[:trace]
           )
-        end,
-        finalized_at: deserialize.call("finalized_at"),
-        kind: deserialize.call("kind"),
-        max_attempts: deserialize.call("max_attempts"),
-        priority: deserialize.call("priority"),
-        queue: deserialize.call("queue"),
-        scheduled_at: deserialize.call("scheduled_at"),
-        state: deserialize.call("state"),
-        tags: deserialize.call("tags")
+        },
+        finalized_at: river_job.finalized_at,
+        kind: river_job.kind,
+        max_attempts: river_job.max_attempts,
+        priority: river_job.priority,
+        queue: river_job.queue,
+        scheduled_at: river_job.scheduled_at,
+        state: river_job.state,
+        tags: river_job.tags
       )
     end
   end

--- a/drivers/riverqueue-sequel/lib/driver.rb
+++ b/drivers/riverqueue-sequel/lib/driver.rb
@@ -22,22 +22,27 @@ module River::Driver
     end
 
     def insert(insert_params)
+      to_job_row(RiverJob.create(insert_params_to_hash(insert_params)))
+    end
+
+    def insert_many(insert_params_many)
+      RiverJob.multi_insert(insert_params_many.map { |p| insert_params_to_hash(p) })
+      insert_params_many.count
+    end
+
+    private def insert_params_to_hash(insert_params)
       # the call to `#compact` is important so that we remove nils and table
       # default values get picked up instead
-      to_job_row(
-        RiverJob.create(
-          {
-            args: insert_params.encoded_args,
-            kind: insert_params.kind,
-            max_attempts: insert_params.max_attempts,
-            priority: insert_params.priority,
-            queue: insert_params.queue,
-            state: insert_params.state,
-            scheduled_at: insert_params.scheduled_at,
-            tags: insert_params.tags ? ::Sequel.pg_array(insert_params.tags) : nil
-          }.compact
-        )
-      )
+      {
+        args: insert_params.encoded_args,
+        kind: insert_params.kind,
+        max_attempts: insert_params.max_attempts,
+        priority: insert_params.priority,
+        queue: insert_params.queue,
+        state: insert_params.state,
+        scheduled_at: insert_params.scheduled_at,
+        tags: insert_params.tags ? ::Sequel.pg_array(insert_params.tags) : nil
+      }.compact
     end
 
     private def to_job_row(river_job)

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -20,8 +20,21 @@ module River
       @driver = driver
     end
 
+    EMPTY_INSERT_OPTS = InsertOpts.new.freeze
+    private_constant :EMPTY_INSERT_OPTS
+
     # Inserts a new job for work given a job args implementation and insertion
     # options (which may be omitted).
+    #
+    # With job args only:
+    #
+    #   insert_res = client.insert(SimpleArgs.new(job_num: 1))
+    #   insert_res.job # inserted job row
+    #
+    # With insert opts:
+    #
+    #   insert_res = client.insert(SimpleArgs.new(job_num: 1), insert_opts: InsertOpts.new(queue: "high_priority"))
+    #   insert_res.job # inserted job row
     #
     # Job arg implementations are expected to respond to:
     #
@@ -34,34 +47,25 @@ module River
     # kind. Insertion options provided as an argument to `#insert` override
     # those returned by job args.
     #
+    # For example:
+    #
+    #   class SimpleArgs
+    #     attr_accessor :job_num
+    #
+    #     def initialize(job_num:)
+    #       self.job_num = job_num
+    #     end
+    #
+    #     def kind = "simple"
+    #
+    #     def to_json = JSON.dump({job_num: job_num})
+    #   end
+    #
+    # See also JobArgsHash for an easy way to insert a job from a hash.
+    #
     # Returns an instance of InsertResult.
-    def insert(args, insert_opts: InsertOpts.new)
-      raise "args should respond to `#kind`" if !args.respond_to?(:kind)
-
-      # ~all objects in Ruby respond to `#to_json`, so check non-nil instead.
-      args_json = args.to_json
-      raise "args should return non-nil from `#to_json`" if !args_json
-
-      args_insert_opts = if args.respond_to?(:insert_opts)
-        args_with_insert_opts = args #: _JobArgsWithInsertOpts # rubocop:disable Layout/LeadingCommentSpace
-        args_with_insert_opts.insert_opts || InsertOpts.new
-      else
-        InsertOpts.new
-      end
-
-      scheduled_at = insert_opts.scheduled_at || args_insert_opts.scheduled_at
-
-      job = @driver.insert(Driver::JobInsertParams.new(
-        encoded_args: args_json,
-        kind: args.kind,
-        max_attempts: insert_opts.max_attempts || args_insert_opts.max_attempts || MAX_ATTEMPTS_DEFAULT,
-        priority: insert_opts.priority || args_insert_opts.priority || PRIORITY_DEFAULT,
-        queue: insert_opts.queue || args_insert_opts.queue || QUEUE_DEFAULT,
-        scheduled_at: scheduled_at&.utc, # database defaults to now
-        state: scheduled_at ? JOB_STATE_SCHEDULED : JOB_STATE_AVAILABLE,
-        tags: insert_opts.tags || args_insert_opts.tags
-      ))
-
+    def insert(args, insert_opts: EMPTY_INSERT_OPTS)
+      job = @driver.insert(make_insert_params(args, insert_opts))
       InsertResult.new(job)
     end
 
@@ -71,15 +75,81 @@ module River
     # Takes an array of job args or InsertManyParams which encapsulate job args
     # and a paired InsertOpts.
     #
+    # With job args:
+    #
+    #   num_inserted = client.insert_many([
+    #     SimpleArgs.new(job_num: 1),
+    #     SimpleArgs.new(job_num: 2)
+    #   ])
+    #
+    # With InsertManyParams:
+    #
+    #   num_inserted = client.insert_many([
+    #     River::InsertManyParams.new(SimpleArgs.new(job_num: 1), insert_opts: InsertOpts.new(max_attempts: 5)),
+    #     River::InsertManyParams.new(SimpleArgs.new(job_num: 2), insert_opts: InsertOpts.new(queue: "high_priority"))
+    #   ])
+    #
     # Job arg implementations are expected to respond to:
     #
     #   * `#kind`: A string that uniquely identifies the job in the database.
     #   * `#to_json`: Encodes the args to JSON for persistence in the database.
     #     Must match encoding an args struct on the Go side to be workable.
     #
+    # For example:
+    #
+    #   class SimpleArgs
+    #     attr_accessor :job_num
+    #
+    #     def initialize(job_num:)
+    #       self.job_num = job_num
+    #     end
+    #
+    #     def kind = "simple"
+    #
+    #     def to_json = JSON.dump({job_num: job_num})
+    #   end
+    #
+    # See also JobArgsHash for an easy way to insert a job from a hash.
+    #
     # Returns the number of jobs inserted.
     def insert_many(args)
-      raise "sorry, not implemented yet"
+      all_params = args.map do |arg|
+        if arg.is_a?(InsertManyParams)
+          make_insert_params(arg.args, arg.insert_opts || EMPTY_INSERT_OPTS)
+        else # jobArgs
+          make_insert_params(arg, EMPTY_INSERT_OPTS)
+        end
+      end
+
+      @driver.insert_many(all_params)
+    end
+
+    private def make_insert_params(args, insert_opts)
+      raise "args should respond to `#kind`" if !args.respond_to?(:kind)
+
+      # ~all objects in Ruby respond to `#to_json`, so check non-nil instead.
+      args_json = args.to_json
+      raise "args should return non-nil from `#to_json`" if !args_json
+
+      args_insert_opts = if args.respond_to?(:insert_opts)
+        args_with_insert_opts = args #: _JobArgsWithInsertOpts # rubocop:disable Layout/LeadingCommentSpace
+        args_with_insert_opts.insert_opts || EMPTY_INSERT_OPTS
+      else
+        EMPTY_INSERT_OPTS
+      end
+
+      scheduled_at = insert_opts.scheduled_at || args_insert_opts.scheduled_at
+
+      Driver::JobInsertParams.new(
+        encoded_args: args_json,
+        kind: args.kind,
+        max_attempts: insert_opts.max_attempts || args_insert_opts.max_attempts || MAX_ATTEMPTS_DEFAULT,
+        priority: insert_opts.priority || args_insert_opts.priority || PRIORITY_DEFAULT,
+        queue: insert_opts.queue || args_insert_opts.queue || QUEUE_DEFAULT,
+        scheduled_at: scheduled_at&.utc, # database defaults to now
+        state: scheduled_at ? JOB_STATE_SCHEDULED : JOB_STATE_AVAILABLE,
+        tags: insert_opts.tags || args_insert_opts.tags
+      )
     end
   end
 

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -11,6 +11,12 @@ module River
   # way to insert a job without having to define a class. The first argument is
   # a "kind" string for identifying the job in the database and the second is a
   # hash that will be encoded to JSON.
+  #
+  # For example:
+  #
+  #   insert_res = client.insert(River::JobArgsHash.new("job_kind", {
+  #     job_num: 1
+  #   }))
   class JobArgsHash
     def initialize(kind, hash)
       raise "kind should be non-nil" if !kind

--- a/lib/riverqueue.rb
+++ b/lib/riverqueue.rb
@@ -1,9 +1,10 @@
 require "json"
 
-require_relative "client"
-require_relative "driver"
 require_relative "insert_opts"
 require_relative "job"
+
+require_relative "client"
+require_relative "driver"
 
 module River
 end

--- a/sig/client.rbs
+++ b/sig/client.rbs
@@ -6,9 +6,13 @@ module River
   class Client
     @driver: _Driver
 
+    EMPTY_INSERT_OPTS: InsertOpts
+
     def initialize: (_Driver driver) -> void
     def insert: (jobArgs, ?insert_opts: InsertOpts) -> InsertResult
     def insert_many: (Array[jobArgs | InsertManyParams]) -> Integer
+
+    private def make_insert_params: (jobArgs, InsertOpts) -> Driver::JobInsertParams
   end
 
   class InsertManyParams
@@ -19,6 +23,7 @@ module River
     attr_reader insert_opts: InsertOpts?
 
     def initialize: (jobArgs job, ?insert_opts: InsertOpts?) -> void
+    def is_a?: (Class) -> bool
   end
 
   class InsertResult

--- a/sig/driver.rbs
+++ b/sig/driver.rbs
@@ -1,6 +1,7 @@
 module River
   interface _Driver
     def insert: (Driver::JobInsertParams) -> JobRow
+    def insert_many: (Array[Driver::JobInsertParams]) -> Integer
   end
 
   module Driver

--- a/sig/insert_opts.rbs
+++ b/sig/insert_opts.rbs
@@ -1,15 +1,10 @@
 module River
   class InsertOpts
     attr_accessor max_attempts: Integer?
-
     attr_accessor priority: Integer?
-
     attr_accessor queue: String?
-
     attr_accessor scheduled_at: Time?
-
     attr_accessor tags: Array[String]?
-
     attr_accessor unique_opts: UniqueOpts?
 
     def initialize: (?max_attempts: Integer?, ?priority: Integer?, ?queue: String?, ?scheduled_at: Time?, ?tags: Array[String]?, ?unique_opts: UniqueOpts?) -> void

--- a/sig/job.rbs
+++ b/sig/job.rbs
@@ -10,6 +10,7 @@ module River
   type jobStateAll = "available" | "cancelled" | "completed" | "discarded" | "retryable" | "running" | "scheduled"
 
   interface _JobArgs
+    def is_a?: (Class) -> bool
     def kind: () -> String
     def respond_to?: (Symbol) -> bool
     def to_json: () -> String


### PR DESCRIPTION
Implement `#insert_many` to support inserting jobs in bulk, similar to
what the Go client supports. For better ergonomics, takes either an
array of job args, or an array of `InsertManyParams`, which is a tuple
of job args and insert opts (again, very similar to the Go API).

Also, I seem to have found a way to reimplement the ActiveRecord driver
so that it doesn't have to drop down to Arel, which ends up simplifying
the code quite a bit and making it more alike the Sequel driver.

Lastly, tighten up documentation somewhat by including code example for
the important API methods.