### PR TITLE
Prepare release for `v0.2.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    riverqueue (0.1.0)
+    riverqueue (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,21 +44,24 @@ $ open coverage/index.html
 
 ## Publish gems
 
-Update `CHANGELOG.md` to include the new version and open a pull request with the changes.
-
 ```shell
 git checkout master && git pull --rebase
 export VERSION=v0.0.x
 
-ruby scripts/update_gemspec_version.rb riverqueue.gemspec > riverqueue.gemspec
+ruby scripts/update_gemspec_version.rb riverqueue.gemspec
+ruby scripts/update_gemspec_version.rb drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
+ruby scripts/update_gemspec_version.rb drivers/riverqueue-sequel/riverqueue-sequel.gemspec
+```
+
+Update `CHANGELOG.md` to include the new version and open a pull request with those changes and the ones to the gemspecs above.
+
+```shell
 gem build riverqueue.gemspec
 gem push riverqueue-${"${VERSION}"/v/}.gem
 
-ruby scripts/update_gemspec_version.rb drivers/riverqueue-activerecord.gemspec > drivers/riverqueue-activerecord.gemspec
 pushd drivers/riverqueue-activerecord && gem build riverqueue-activerecord.gemspec && popd
 pushd drivers/riverqueue-activerecord && gem push riverqueue-activerecord-${"${VERSION}"/v/}.gem && popd
 
-ruby scripts/update_gemspec_version.rb drivers/riverqueue-sequel.gemspec > drivers/riverqueue-sequel.gemspec
 pushd drivers/riverqueue-sequel && gem build riverqueue-sequel.gemspec && popd
 pushd drivers/riverqueue-sequel && gem push riverqueue-sequel-${"${VERSION}"/v/}.gem && popd
 

--- a/drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-activerecord"
-  s.version = "0.1.0"
+  s.version = "0.2.0"
   s.summary = "ActiveRecord driver for the River Ruby gem."
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/drivers/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/drivers/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-sequel"
-  s.version = "0.1.0"
+  s.version = "0.2.0"
   s.summary = "Sequel driver for the River Ruby gem."
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue"
-  s.version = "0.1.0"
+  s.version = "0.2.0"
   s.summary = "River is a fast job queue for Go."
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/scripts/update_gemspec_version.rb
+++ b/scripts/update_gemspec_version.rb
@@ -8,8 +8,10 @@ version = ENV["VERSION"] || abort("failure: need VERSION")
 
 file_data = File.read(file)
 
-updated_file_data = file_data.gsub(%r{^(\W+)s\.version = "0.2.0"$}, %(\\1s.version = "#{version}"))
+version = version[1..] # strip `v` from the beginning of the string
+
+updated_file_data = file_data.gsub(%r{^(\W+)s\.version = "[\d\.]+"$}, %(\\1s.version = "#{version}"))
 
 abort("failure: nothing changed in file") if file_data == updated_file_data
 
-puts updated_file_data
+File.write(file, updated_file_data)


### PR DESCRIPTION
Updates gemspecs for `v0.2.0`, and also fixes up the gemspec update
script and release instructions as we iron out this whole process.