### PR TITLE
Update development instructions again + update `Gemfile.lock`s

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -44,27 +44,32 @@ $ open coverage/index.html
 
 ## Publish gems
 
-```shell
-git checkout master && git pull --rebase
-export VERSION=v0.0.x
+1. Choose a version, run scripts to update the versions in each gemspec file, and build each gem which will update its `Gemfile.lock` with the new version:
 
-ruby scripts/update_gemspec_version.rb riverqueue.gemspec
-ruby scripts/update_gemspec_version.rb drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
-ruby scripts/update_gemspec_version.rb drivers/riverqueue-sequel/riverqueue-sequel.gemspec
-```
+    ```shell
+    git checkout master && git pull --rebase
+    export VERSION=v0.0.x
 
-Update `CHANGELOG.md` to include the new version and open a pull request with those changes and the ones to the gemspecs above.
+    ruby scripts/update_gemspec_version.rb riverqueue.gemspec
+    ruby scripts/update_gemspec_version.rb drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
+    ruby scripts/update_gemspec_version.rb drivers/riverqueue-sequel/riverqueue-sequel.gemspec
 
-```shell
-gem build riverqueue.gemspec
-gem push riverqueue-${"${VERSION}"/v/}.gem
+    gem build riverqueue.gemspec
+    pushd drivers/riverqueue-activerecord && gem build riverqueue-activerecord.gemspec && popd
+    pushd drivers/riverqueue-sequel && gem build riverqueue-sequel.gemspec && popd
+    ```
 
-pushd drivers/riverqueue-activerecord && gem build riverqueue-activerecord.gemspec && popd
-pushd drivers/riverqueue-activerecord && gem push riverqueue-activerecord-${"${VERSION}"/v/}.gem && popd
+2. Update `CHANGELOG.md` to include the new version and open a pull request with those changes and the ones to the gemspecs and `Gemfile.lock`s above.
 
-pushd drivers/riverqueue-sequel && gem build riverqueue-sequel.gemspec && popd
-pushd drivers/riverqueue-sequel && gem push riverqueue-sequel-${"${VERSION}"/v/}.gem && popd
+3. Build and push each gem, then tag the release and push that:
 
-git tag $VERSION
-git push --tags
-```
+    ```shell
+    gem push riverqueue-${"${VERSION}"/v/}.gem
+    pushd drivers/riverqueue-activerecord && gem push riverqueue-activerecord-${"${VERSION}"/v/}.gem && popd
+    pushd drivers/riverqueue-sequel && gem push riverqueue-sequel-${"${VERSION}"/v/}.gem && popd
+
+    git tag $VERSION
+    git push --tags
+    ```
+
+4. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/river/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.

--- a/drivers/riverqueue-activerecord/Gemfile.lock
+++ b/drivers/riverqueue-activerecord/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.1.0)
+    riverqueue (0.2.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-activerecord (0.1.0)
+    riverqueue-activerecord (0.2.0)
       activerecord (> 0, < 1000)
       activesupport (> 0, < 1000)
       pg (> 0, < 1000)

--- a/drivers/riverqueue-sequel/Gemfile.lock
+++ b/drivers/riverqueue-sequel/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.1.0)
+    riverqueue (0.2.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-sequel (0.1.0)
+    riverqueue-sequel (0.2.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 


### PR DESCRIPTION
Update development instructions (again) so that we build the gem as part
of the first step so that `Gemfile.lock`s are updated with the new
version and can be checked in as part of the version release.

Also update a few `Gemfile.lock` updates that were left out of the 0.2.0
release due to this omission.