### PR TITLE
Prepare release `v0.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-04-27
+
 ### Added
 
 - Implement unique job insertion. [PR #10](https://github.com/riverqueue/riverqueue-ruby/pull/10).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    riverqueue (0.2.0)
+    riverqueue (0.3.0)
       fnv-hash
 
 GEM

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,7 +44,7 @@ $ open coverage/index.html
 
 ## Publish gems
 
-1. Choose a version, run scripts to update the versions in each gemspec file, and build each gem which will update its `Gemfile.lock` with the new version:
+1. Choose a version, run scripts to update the versions in each gemspec file, build each gem, and `bundle install` which will update its `Gemfile.lock` with the new version:
 
     ```shell
     git checkout master && git pull --rebase
@@ -57,6 +57,12 @@ $ open coverage/index.html
     gem build riverqueue.gemspec
     pushd drivers/riverqueue-activerecord && gem build riverqueue-activerecord.gemspec && popd
     pushd drivers/riverqueue-sequel && gem build riverqueue-sequel.gemspec && popd
+
+    bundle install
+    pushd drivers/riverqueue-activerecord && bundle install && popd
+    pushd drivers/riverqueue-sequel && bundle install && popd
+
+    gco -b $USER-$VERSION
     ```
 
 2. Update `CHANGELOG.md` to include the new version and open a pull request with those changes and the ones to the gemspecs and `Gemfile.lock`s above.
@@ -72,4 +78,4 @@ $ open coverage/index.html
     git push --tags
     ```
 
-4. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/riverqueue-ruby/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.
+4. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/river/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.

--- a/drivers/riverqueue-activerecord/Gemfile.lock
+++ b/drivers/riverqueue-activerecord/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.2.0)
+    riverqueue (0.3.0)
       fnv-hash
 
 PATH
   remote: .
   specs:
-    riverqueue-activerecord (0.2.0)
+    riverqueue-activerecord (0.3.0)
       activerecord (> 0, < 1000)
       activesupport (> 0, < 1000)
       pg (> 0, < 1000)

--- a/drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-activerecord"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
   s.summary = "ActiveRecord driver for the River Ruby gem."
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/drivers/riverqueue-sequel/Gemfile.lock
+++ b/drivers/riverqueue-sequel/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.2.0)
+    riverqueue (0.3.0)
       fnv-hash
 
 PATH
   remote: .
   specs:
-    riverqueue-sequel (0.2.0)
+    riverqueue-sequel (0.3.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 

--- a/drivers/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/drivers/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-sequel"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
   s.summary = "Sequel driver for the River Ruby gem."
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
   s.summary = "River is a fast job queue for Go."
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]


### PR DESCRIPTION
Prepare release `v0.3.0` which largely includes unique jobs from #10.
Also tweak the publishing instructions, which were once again, still
somewhat wrong (building a gem doesn't lead directly to an updated
`Gemfile.lock`).