### PR TITLE
Improve tests for advisory locks

### DIFF
--- a/drivers/riverqueue-sequel/spec/driver_spec.rb
+++ b/drivers/riverqueue-sequel/spec/driver_spec.rb
@@ -67,7 +67,13 @@ RSpec.describe River::Driver::Sequel do
 
   describe "#advisory_lock" do
     it "takes an advisory lock" do
-      driver.advisory_lock(123)
+      driver.transaction do
+        driver.advisory_lock(123)
+
+        Thread.new do
+          expect(DB.fetch("SELECT pg_try_advisory_xact_lock(?)", 123).first[:pg_try_advisory_xact_lock]).to be false
+        end.join
+      end
     end
   end
 


### PR DESCRIPTION
Improve tests for advisory locks so that we actually check that the
advisory lock is held from another thread. Both ActiveRecord and Sequel
have a lot of laziness, so where an SQL command doesn't have a checked
result, it's easy to think you've invoked it, but only have a lazy data
set instead.