### PR TITLE
add source_code_uri and other metadata to gemspec

### DIFF
--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -8,6 +8,12 @@ Gem::Specification.new do |s|
   s.files = ["lib/riverqueue.rb"]
   s.homepage = "https://riverqueue.com"
   s.license = "LGPL-3.0-or-later"
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/riverqueue/riverqueue-ruby/issues",
+    "changelog_uri" => "https://github.com/riverqueue/riverqueue-ruby/blob/master/CHANGELOG.md",
+    "rubygems_mfa_required" => "true",
+    "source_code_uri" => "https://github.com/riverqueue/riverqueue-ruby"
+  }
 
   s.add_dependency "fnv-hash"
 end


### PR DESCRIPTION
Per https://guides.rubygems.org/specification-reference/#metadata

Also some inspiration drawn from AR:

https://github.com/rails/rails/blob/v7.1.3.2/activerecord/activerecord.gemspec