### PR TITLE
Prepare release `v0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-04-28
+
 ### Changed
 
 - Implement the FNV (Fowler–Noll–Vo) hashing algorithm in the project and drop dependency on the `fnv-hash` gem. [PR #14](https://github.com/riverqueue/riverqueue-ruby/pull/14).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    riverqueue (0.3.0)
+    riverqueue (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,6 +72,8 @@ $ open coverage/index.html
 3. Build and push each gem, then tag the release and push that:
 
     ```shell
+    git pull
+
     gem push riverqueue-${"${VERSION}"/v/}.gem
     pushd drivers/riverqueue-activerecord && gem push riverqueue-activerecord-${"${VERSION}"/v/}.gem && popd
     pushd drivers/riverqueue-sequel && gem push riverqueue-sequel-${"${VERSION}"/v/}.gem && popd

--- a/drivers/riverqueue-activerecord/Gemfile.lock
+++ b/drivers/riverqueue-activerecord/Gemfile.lock
@@ -1,13 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.3.0)
-      fnv-hash
+    riverqueue (0.4.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-activerecord (0.3.0)
+    riverqueue-activerecord (0.4.0)
       activerecord (> 0, < 1000)
       activesupport (> 0, < 1000)
       pg (> 0, < 1000)
@@ -42,7 +41,6 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     drb (2.2.1)
-    fnv-hash (0.2.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)

--- a/drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/drivers/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-activerecord"
-  s.version = "0.3.0"
+  s.version = "0.4.0"
   s.summary = "ActiveRecord driver for the River Ruby gem."
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/drivers/riverqueue-sequel/Gemfile.lock
+++ b/drivers/riverqueue-sequel/Gemfile.lock
@@ -1,13 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.3.0)
-      fnv-hash
+    riverqueue (0.4.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-sequel (0.3.0)
+    riverqueue-sequel (0.4.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 
@@ -18,7 +17,6 @@ GEM
     bigdecimal (3.1.7)
     diff-lcs (1.5.1)
     docile (1.4.0)
-    fnv-hash (0.2.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)

--- a/drivers/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/drivers/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-sequel"
-  s.version = "0.3.0"
+  s.version = "0.4.0"
   s.summary = "Sequel driver for the River Ruby gem."
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue"
-  s.version = "0.3.0"
+  s.version = "0.4.0"
   s.summary = "River is a fast job queue for Go."
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]


### PR DESCRIPTION
Prepare release `v0.4.0`, which largely contains #14 which implements
the FNV hashing algorithm and drops the dependency on the `fnv-hash`
gem.