### PR TITLE
Standardize name of test database to `river_test`

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,8 +13,8 @@ Create a test database and migrate with River's CLI:
 
 ```shell
 $ go install github.com/riverqueue/river/cmd/river
-$ createdb riverqueue_ruby_test
-$ river migrate-up --database-url "postgres://localhost/riverqueue_ruby_test"
+$ createdb river_test
+$ river migrate-up --database-url "postgres://localhost/river_test"
 ```
 
 Run all specs:

--- a/drivers/riverqueue-activerecord/docs/development.md
+++ b/drivers/riverqueue-activerecord/docs/development.md
@@ -11,8 +11,8 @@ Create a test database and migrate with River's CLI:
 
 ```shell
 $ go install github.com/riverqueue/river/cmd/river
-$ createdb riverqueue_ruby_test
-$ river migrate-up --database-url "postgres://localhost/riverqueue_ruby_test"
+$ createdb river_test
+$ river migrate-up --database-url "postgres://localhost/river_test"
 ```
 
 Run all specs:

--- a/drivers/riverqueue-activerecord/spec/spec_helper.rb
+++ b/drivers/riverqueue-activerecord/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require "active_record"
 require "debug"
 
-ActiveRecord::Base.establish_connection(ENV["TEST_DATABASE_URL"] || "postgres://localhost/riverqueue_ruby_test")
+ActiveRecord::Base.establish_connection(ENV["TEST_DATABASE_URL"] || "postgres://localhost/river_test")
 
 def test_transaction
   ActiveRecord::Base.transaction do

--- a/drivers/riverqueue-sequel/docs/development.md
+++ b/drivers/riverqueue-sequel/docs/development.md
@@ -11,8 +11,8 @@ Create a test database and migrate with River's CLI:
 
 ```shell
 $ go install github.com/riverqueue/river/cmd/river
-$ createdb riverqueue_ruby_test
-$ river migrate-up --database-url "postgres://localhost/riverqueue_ruby_test"
+$ createdb river_test
+$ river migrate-up --database-url "postgres://localhost/river_test"
 ```
 
 Run all specs:

--- a/drivers/riverqueue-sequel/spec/spec_helper.rb
+++ b/drivers/riverqueue-sequel/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "sequel"
 
-DB = Sequel.connect(ENV["TEST_DATABASE_URL"] || "postgres://localhost/riverqueue_ruby_test")
+DB = Sequel.connect(ENV["TEST_DATABASE_URL"] || "postgres://localhost/river_test")
 
 def test_transaction
   DB.transaction do


### PR DESCRIPTION
We have a whole bunch of ideas of what the name of the River test
database should be across like all our different projects. I'm going to
try and standardize on `river_test` everywhere, and `river_dev` for the
development database.