### PR TITLE
Small aesthetic improvement to the FNV implementation

### DIFF
--- a/lib/fnv.rb
+++ b/lib/fnv.rb
@@ -8,23 +8,17 @@ module River
   module FNV
     def self.fnv1_hash(str, size:)
       hash = OFFSET_BASIS.fetch(size)
-      mask = MASK.fetch(size)
+      mask = (2**size - 1).to_int # creates a mask of 1s of `size` bits long like 0xffffffff
       prime = PRIME.fetch(size)
 
       str.each_byte do |byte|
         hash *= prime
-        hash &= mask # take lower N bits of multiplication product
+        hash &= mask
         hash ^= byte
       end
 
       hash
     end
-
-    MASK = {
-      32 => 0xffffffff, # mask 32 bits long
-      64 => 0xffffffffffffffff # mask 64 bits long
-    }.freeze
-    private_constant :MASK
 
     OFFSET_BASIS = {
       32 => 0x811c9dc5,

--- a/spec/fnv_spec.rb
+++ b/spec/fnv_spec.rb
@@ -14,14 +14,6 @@ describe River::FNV do
       end
     end
   end
-
-  # Just a sanity check to make sure the number of 0xffs is right.
-  describe "MASK" do
-    it "contains masks equal to integer limits" do
-      expect(River::FNV.const_get(:MASK)[32]).to eq(4_294_967_295)
-      expect(River::FNV.const_get(:MASK)[64]).to eq(18_446_744_073_709_551_615)
-    end
-  end
 end
 
 #


### PR DESCRIPTION
An improvement to the FNV implementation that calculates a bitmask using
a power of two minus one instead of hardcoding them.

    2^32-1 == 0xffffffff