### PR TITLE
Add help target for `Makefile` that iterates targets with basic docstring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
+.DEFAULT_GOAL := help
+
+# Looks at comments using ## on targets and uses them to produce a help output.
+.PHONY: help
+help: ALIGN=14
+help: ## Print this message
+	@awk -F ': .*## ' -- "/^[^':]+: .*## /"' { printf "'$$(tput bold)'%-$(ALIGN)s'$$(tput sgr0)' %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
 .PHONY: lint
-lint: standardrb
+lint: standardrb ## Run linter (standardrb)
 
 .PHONY: rspec
 rspec: spec
@@ -21,7 +29,7 @@ steep:
 	bundle exec steep check
 
 .PHONY: test
-test: spec
+test: spec ## Run test suite (Rspec)
 
 .PHONY: type-check
-type-check: steep
+type-check: steep ## Run type check with Steep


### PR DESCRIPTION
Uses a Make trick to add a help target to the Makefile that iterates
targets with basic docstrings that are extracted from the line where the
target is defined behind a double-hash like `##`:

    help: ## Print this message

Invocation:

    $ make help
    help           Print this message
    lint           Run linter (standardrb)
    test           Run test suite (Rspec)
    type-check     Run type check with Steep

We also make `help` the default invocation so running `make` with
nothing else will print the same thing:

    $ make
    help           Print this message
    lint           Run linter (standardrb)
    test           Run test suite (Rspec)
    type-check     Run type check with Steep