### PR TITLE
Add `require` statements to client initialization example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,11 @@ gem "riverqueue-sequel"
 Initialize a client with:
 
 ```ruby
+require "riverqueue"
+require "riverqueue-activerecord"
+
 DB = Sequel.connect("postgres://...")
-client = River::Client.new(River::Driver::Sequel.new(DB))
+client = River::Client.new(River::Driver::ActiveRecord.new)
 ```
 
 Define a job and insert it:


### PR DESCRIPTION
Make the client initialization example more useful by adding `require`
statements to help users see the entirety of the code they need to write
to make it work. Also change Sequel to ActiveRecord to match a change
that was made to the homepage docs.