### PR TITLE
Check tag format + return metadata + additional doc strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tag format is now checked on insert. Tags should be no more than 255 characters and match the regex `/\A[\w][\w\-]+[\w]\z/`. [PR #22](https://github.com/riverqueue/riverqueue-ruby/pull/22).
+- Returned jobs now have a `metadata` property. [PR #21](https://github.com/riverqueue/riverqueue-ruby/pull/22).
+
 ## [0.4.0] - 2024-04-28
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ insert_res.unique_skipped_as_duplicated
 
 ### Custom advisory lock prefix
 
-Unique job insertion takes a Postgres advisory lock to make sure that it's uniqueness check still works even if two conflicting insert operations are occurring in parallel. Postgres advisory locks share a global 64-bit namespace, which is a large enough space that it's unlikely for two advisory locks to ever conflict, but to _guarantee_ that River's advisory locks never interfere with an application's, River can be configured with a 32-bit advisory lock prefix which it will use for all its locks:
+Unique job insertion takes a Postgres advisory lock to make sure that its uniqueness check still works even if two conflicting insert operations are occurring in parallel. Postgres advisory locks share a global 64-bit namespace, which is a large enough space that it's unlikely for two advisory locks to ever conflict, but to _guarantee_ that River's advisory locks never interfere with an application's, River can be configured with a 32-bit advisory lock prefix which it will use for all its locks:
 
 ```ruby
 client = River::Client.new(mock_driver, advisory_lock_prefix: 123456)

--- a/driver/riverqueue-activerecord/lib/driver.rb
+++ b/driver/riverqueue-activerecord/lib/driver.rb
@@ -100,6 +100,7 @@ module River::Driver
         finalized_at: river_job.finalized_at,
         kind: river_job.kind,
         max_attempts: river_job.max_attempts,
+        metadata: river_job.metadata,
         priority: river_job.priority,
         queue: river_job.queue,
         scheduled_at: river_job.scheduled_at,

--- a/driver/riverqueue-sequel/lib/driver.rb
+++ b/driver/riverqueue-sequel/lib/driver.rb
@@ -86,6 +86,7 @@ module River::Driver
         finalized_at: river_job.finalized_at,
         kind: river_job.kind,
         max_attempts: river_job.max_attempts,
+        metadata: river_job.metadata,
         priority: river_job.priority,
         queue: river_job.queue,
         scheduled_at: river_job.scheduled_at,

--- a/lib/job.rb
+++ b/lib/job.rb
@@ -55,15 +55,15 @@ module River
     # The set of worker IDs that have worked this job. A worker ID differs
     # between different programs, but is shared by all executors within any
     # given one.  (i.e. Different Go processes have different IDs, but IDs are
-    # shared within any given process.) A process generates a new ULID (an
-    # ordered UUID) worker ID when it starts up.
+    # shared within any given process.) A process generates a new ID based on
+    # host and current time when it starts up.
     attr_accessor :attempted_by
 
     # When the job record was created.
     attr_accessor :created_at
 
     # A set of errors that occurred when the job was worked, one for each
-    # attempt.  Ordered from earliest error to the latest error.
+    # attempt. Ordered from earliest error to the latest error.
     attr_accessor :errors
 
     # The time at which the job was "finalized", meaning it was either completed
@@ -78,6 +78,9 @@ module River
     # The maximum number of attempts that the job will be tried before it errors
     # for the last time and will no longer be worked.
     attr_accessor :max_attempts
+
+    # Arbitrary metadata associated with the job.
+    attr_accessor :metadata
 
     # The priority of the job, with 1 being the highest priority and 4 being the
     # lowest. When fetching available jobs to work, the highest priority jobs
@@ -112,6 +115,7 @@ module River
       created_at:,
       kind:,
       max_attempts:,
+      metadata:,
       priority:,
       queue:,
       scheduled_at:,
@@ -134,6 +138,7 @@ module River
       self.finalized_at = finalized_at
       self.kind = kind
       self.max_attempts = max_attempts
+      self.metadata = metadata
       self.priority = priority
       self.queue = queue
       self.scheduled_at = scheduled_at
@@ -157,7 +162,7 @@ module River
     attr_accessor :error
 
     # Contains a stack trace from a job that panicked. The trace is produced by
-    # invoking `debug.Trace()`.
+    # invoking `debug.Trace()` in Go.
     attr_accessor :trace
 
     def initialize(

--- a/sig/client.rbs
+++ b/sig/client.rbs
@@ -16,9 +16,13 @@ module River
     def insert_many: (Array[jobArgs | InsertManyParams]) -> Integer
 
     private def check_unique_job: (Driver::JobInsertParams, UniqueOpts?) { () -> InsertResult } -> InsertResult
-    private def uint64_to_int64: (Integer) -> Integer
     private def make_insert_params: (jobArgs, InsertOpts, ?is_insert_many: bool) -> [Driver::JobInsertParams, UniqueOpts?]
     private def truncate_time: (Time, Integer) -> Time
+    private def uint64_to_int64: (Integer) -> Integer
+
+    TAG_RE: Regexp
+
+    private def validate_tags: (Array[String]?) -> Array[String]?
   end
 
   class InsertManyParams

--- a/sig/job.rbs
+++ b/sig/job.rbs
@@ -45,13 +45,14 @@ module River
     attr_accessor finalized_at: Time?
     attr_accessor kind: String
     attr_accessor max_attempts: Integer
+    attr_accessor metadata: Hash[String, untyped]
     attr_accessor priority: Integer
     attr_accessor queue: String
     attr_accessor scheduled_at: Time
     attr_accessor state: jobStateAll
     attr_accessor tags: Array[String]?
 
-    def initialize: (id: Integer, args: Hash[String, untyped], attempt: Integer, ?attempted_at: Time?, ?attempted_by: String?, created_at: Time, ?errors: Array[AttemptError]?, ?finalized_at: Time?, kind: String, max_attempts: Integer, priority: Integer, queue: String, scheduled_at: Time, state: jobStateAll, ?tags: Array[String]?) -> void
+    def initialize: (id: Integer, args: Hash[String, untyped], attempt: Integer, ?attempted_at: Time?, ?attempted_by: String?, created_at: Time, ?errors: Array[AttemptError]?, ?finalized_at: Time?, kind: String, max_attempts: Integer, metadata: Hash[String, untyped], priority: Integer, queue: String, scheduled_at: Time, state: jobStateAll, ?tags: Array[String]?) -> void
   end
 
   class AttemptError


### PR DESCRIPTION
Mainly, bring in tag format checks which verify they're shorter than 255
characters and don't contain any special characters (especially commas),
like Go and Python do already.

Start returning metadata in jobs, although notably, it's not possible to
insert with it yet.

A few additional docstrings brought over from my project to document
River Python.