### PR TITLE
Prepare release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-07-05
+
 ### Changed
 
 - Tag format is now checked on insert. Tags should be no more than 255 characters and match the regex `/\A[\w][\w\-]+[\w]\z/`. [PR #22](https://github.com/riverqueue/riverqueue-ruby/pull/22).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    riverqueue (0.4.0)
+    riverqueue (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,7 +50,7 @@ $ open coverage/index.html
 
     ```shell
     git checkout master && git pull --rebase
-    export VERSION=v0.0.x
+    export VERSION=v0.x.0
 
     ruby scripts/update_gemspec_version.rb riverqueue.gemspec
     ruby scripts/update_gemspec_version.rb driver/riverqueue-activerecord/riverqueue-activerecord.gemspec

--- a/driver/riverqueue-activerecord/Gemfile.lock
+++ b/driver/riverqueue-activerecord/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.4.0)
+    riverqueue (0.5.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-activerecord (0.4.0)
+    riverqueue-activerecord (0.5.0)
       activerecord (> 0, < 1000)
       activesupport (> 0, < 1000)
       pg (> 0, < 1000)

--- a/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-activerecord"
-  s.version = "0.4.0"
+  s.version = "0.5.0"
   s.summary = "ActiveRecord driver for the River Ruby gem."
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/driver/riverqueue-sequel/Gemfile.lock
+++ b/driver/riverqueue-sequel/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.4.0)
+    riverqueue (0.5.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-sequel (0.4.0)
+    riverqueue-sequel (0.5.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 

--- a/driver/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/driver/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-sequel"
-  s.version = "0.4.0"
+  s.version = "0.5.0"
   s.summary = "Sequel driver for the River Ruby gem."
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue"
-  s.version = "0.4.0"
+  s.version = "0.5.0"
   s.summary = "River is a fast job queue for Go."
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]


### PR DESCRIPTION
Prepare release 0.5.0, which now validates tags and adds a `metadata`
property to inserted jobs.