### PR TITLE
Check that advisory lock prefix fits inside four bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Advisory lock prefixes are now checked to make sure they fit inside of four bytes. [PR #24](https://github.com/riverqueue/riverqueue-ruby/pull/24).
+
 ## [0.5.0] - 2024-07-05
 
 ### Changed

--- a/sig/client.rbs
+++ b/sig/client.rbs
@@ -8,12 +8,14 @@ module River
     @driver: _Driver
     @time_now_utc: ^() -> Time
 
-    DEFAULT_UNIQUE_STATES: Array[jobStateAll]
-    EMPTY_INSERT_OPTS: InsertOpts
-
     def initialize: (_Driver driver, ?advisory_lock_prefix: Integer?) -> void
     def insert: (jobArgs, ?insert_opts: InsertOpts) -> InsertResult
     def insert_many: (Array[jobArgs | InsertManyParams]) -> Integer
+
+    private def check_advisory_lock_prefix_bounds: (Integer?) -> Integer?
+
+    DEFAULT_UNIQUE_STATES: Array[jobStateAll]
+    EMPTY_INSERT_OPTS: InsertOpts
 
     private def check_unique_job: (Driver::JobInsertParams, UniqueOpts?) { () -> InsertResult } -> InsertResult
     private def make_insert_params: (jobArgs, InsertOpts, ?is_insert_many: bool) -> [Driver::JobInsertParams, UniqueOpts?]

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -173,6 +173,22 @@ RSpec.describe River::Client do
       )
     end
 
+    it "errors if advisory lock prefix is larger than four bytes" do
+      River::Client.new(mock_driver, advisory_lock_prefix: 123)
+
+      expect do
+        River::Client.new(mock_driver, advisory_lock_prefix: -1)
+      end.to raise_error(ArgumentError, "advisory lock prefix must fit inside four bytes")
+
+      # 2^32-1 is 0xffffffff (1s for 32 bits) which fits
+      River::Client.new(mock_driver, advisory_lock_prefix: 2**32 - 1)
+
+      # 2^32 is 0x100000000, which does not
+      expect do
+        River::Client.new(mock_driver, advisory_lock_prefix: 2**32)
+      end.to raise_error(ArgumentError, "advisory lock prefix must fit inside four bytes")
+    end
+
     it "errors if args don't respond to #kind" do
       args_klass = Class.new do
         def to_json = {}


### PR DESCRIPTION
Add an extra safety check that an advisory lock prefix fits inside of
four bytes, which is all that's reserved for one.