### PR TITLE
Include all files in `lib` paths in various gems

### DIFF
--- a/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]
   s.email = "brandur@brandur.org"
-  s.files = ["lib/riverqueue-activerecord.rb"]
+  s.files = Dir.glob("lib/**/*")
   s.homepage = "https://riverqueue.com"
   s.license = "LGPL-3.0-or-later"
 

--- a/driver/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/driver/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]
   s.email = "brandur@brandur.org"
-  s.files = ["lib/riverqueue-sequel.rb"]
+  s.files = Dir.glob("lib/**/*")
   s.homepage = "https://riverqueue.com"
   s.license = "LGPL-3.0-or-later"
 

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |s|
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]
   s.email = "brandur@brandur.org"
-  s.files = ["lib/riverqueue.rb"]
+  s.files = Dir.glob("lib/**/*")
   s.homepage = "https://riverqueue.com"
   s.license = "LGPL-3.0-or-later"
+  s.require_path = %(lib)
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/riverqueue/riverqueue-ruby/issues",
     "changelog_uri" => "https://github.com/riverqueue/riverqueue-ruby/blob/master/CHANGELOG.md",


### PR DESCRIPTION
My Rails application refused to build after I added the `riverqueue` and `riverqueue-activerecord` gems. The logs suggested that the errors were due to missing files (see attached screenshot). When I checked the gemspec, the `s.files` definition included only one file, for all three gems. I modified them to include all files in the various `lib` directories, changed the gem source to my github fork, and the build succeeded. 

Perhaps this failure is unique to my environment (Docker on Railway, bundler 2.5.17), otherwise maybe the definition should be expanded to include all files in the `lib` directories? This seems to be the default configuration for gems created with `bundle gem GEM_NAME`.

<img width="738" alt="Screenshot 2024-08-21 at 11 08 59" src="https://github.com/user-attachments/assets/9d9de406-29e0-4481-be40-a2fab0487caa">
