### PR TITLE
Prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-08-30
+
 ### Changed
 
 - Now compatible with "fast path" unique job insertion that uses a unique index instead of advisory lock and fetch [as introduced in River #451](https://github.com/riverqueue/river/pull/451). [PR #28](https://github.com/riverqueue/riverqueue-ruby/pull/28).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    riverqueue (0.6.1)
+    riverqueue (0.7.0)
 
 PATH
   remote: driver/riverqueue-sequel
   specs:
-    riverqueue-sequel (0.6.1)
+    riverqueue-sequel (0.7.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 

--- a/driver/riverqueue-activerecord/Gemfile.lock
+++ b/driver/riverqueue-activerecord/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.6.1)
+    riverqueue (0.7.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-activerecord (0.6.1)
+    riverqueue-activerecord (0.7.0)
       activerecord (> 0, < 1000)
       activesupport (> 0, < 1000)
       pg (> 0, < 1000)

--- a/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-activerecord"
-  s.version = "0.6.1"
+  s.version = "0.7.0"
   s.summary = "ActiveRecord driver for the River Ruby gem."
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/driver/riverqueue-sequel/Gemfile.lock
+++ b/driver/riverqueue-sequel/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.6.1)
+    riverqueue (0.7.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-sequel (0.6.1)
+    riverqueue-sequel (0.7.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 

--- a/driver/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/driver/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-sequel"
-  s.version = "0.6.1"
+  s.version = "0.7.0"
   s.summary = "Sequel driver for the River Ruby gem."
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue"
-  s.version = "0.6.1"
+  s.version = "0.7.0"
   s.summary = "River is a fast job queue for Go."
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]


### PR DESCRIPTION
Prepare v0.7.0, containing largely the changes in #28 that add support
for past path unique job insertion.