### PR TITLE
Test against all supported versions of Ruby

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,12 @@ env:
   # to GITHUB_PATH/PATH.
   BIN_PATH: /home/runner/bin
 
+  # The version of Ruby that non-spec tasks like the build check or lint run
+  # against. The setup-ruby step must have a version specified, which is why
+  # this is necessary.
+  #
+  # If updating this value, you probably also want to add a new version to the
+  # spec version matrix below.
   RUBY_VERSION: "3.3"
 
   # A suitable URL for a test database.
@@ -99,6 +105,14 @@ jobs:
   spec:
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    strategy:
+      matrix:
+        # If adding a value, you probably also want to update the default
+        # RUBY_VERSION for non-spec jobs above.
+        ruby_version:
+          - "3.1"
+          - "3.2"
+          - "3.3"
 
     services:
       postgres:
@@ -120,7 +134,7 @@ jobs:
       - name: Install Ruby + `bundle install`
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       # Needed for River's CLI. There is a version of Go on Actions' base image,


### PR DESCRIPTION
Flesh out the matrix of versions of Ruby that we test the gem against,
adding all three versions that are currently considered to be in
maintenance (3.1, 3.2, 3.3) [1].

The setup-ruby step requires a version be specified, so we have a
slightly awkward situation here were non-spec jobs use a default
`RUBY_VERSION` from env, while the spec job gets a matrix containing
more than one version. I've added comments to `RUBY_VERSION` and the
matrix to hopefully suggest to anyone making a modification that
changing one of them probably means you want to update the other too.

[1] https://www.ruby-lang.org/en/downloads/branches/