### PR TITLE
Allow by period uniqueness to be based off scheduled time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `by_period` uniqueness is now based off a job's `scheduled_at` instead of the current time if it has a value. [PR #39](https://github.com/riverqueue/riverqueue-ruby/pull/39).
+
 ## [0.8.0] - 2024-12-19
 
 ⚠️ Version 0.8.0 contains breaking changes to transition to River's new unique jobs implementation and to enable broader, more flexible application of unique jobs. Detailed notes on the implementation are contained in [the original River PR](https://github.com/riverqueue/river/pull/590), and the notes below include short summaries of the ways this impacts this client specifically.

--- a/lib/client.rb
+++ b/lib/client.rb
@@ -220,7 +220,7 @@ module River
       end
 
       if unique_opts.by_period
-        lower_period_bound = truncate_time(@time_now_utc.call, unique_opts.by_period).utc
+        lower_period_bound = truncate_time(insert_params.scheduled_at || @time_now_utc.call, unique_opts.by_period).utc
 
         unique_key += "&period=#{lower_period_bound.strftime("%FT%TZ")}"
       end


### PR DESCRIPTION
This one follows up [1] in the main repository, in which we fix what
could be considered a bug in that by period uniqueness was always based
off the current time, even though a job may have been given a custom
value for `scheduled_at`, which really should take precedence.

[1] https://github.com/riverqueue/river/pull/734