### PR TITLE
Fix typo in examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ client = River::Client.new(River::Driver::ActiveRecord.new)
 Define a job and insert it:
 
 ```ruby
-class SortArgs
+class SimpleArgs
   attr_accessor :strings
 
   def initialize(strings:)


### PR DESCRIPTION
The examples in README declare a `SortArgs` class but use one named `SimpleArgs`. This PR makes the naming consistent.