### PR TITLE
Add `make install` target so it's easy to install deps in all directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .DEFAULT_GOAL := help
 
-.PHONY: bundle-update
-bundle-update: ## Run `bundle update` on gem and all subgems
-	bundle update
-	cd driver/riverqueue-activerecord && bundle update
-	cd driver/riverqueue-sequel && bundle update
-
 # Looks at comments using ## on targets and uses them to produce a help output.
 .PHONY: help
 help: ALIGN=14
 help: ## Print this message
 	@awk -F ': .*## ' -- "/^[^':]+: .*## /"' { printf "'$$(tput bold)'%-$(ALIGN)s'$$(tput sgr0)' %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.PHONY: install
+install: ## Run `bundle install` on gem and all subgems
+	bundle install
+	cd driver/riverqueue-activerecord && bundle install
+	cd driver/riverqueue-sequel && bundle install
 
 .PHONY: lint
 lint: standardrb ## Run linter (standardrb) on gem and all subgems
@@ -39,3 +39,9 @@ test: spec ## Run test suite (rspec) on gem and all subgems
 
 .PHONY: type-check
 type-check: steep ## Run type check with Steep
+
+.PHONY: update
+update: ## Run `bundle update` on gem and all subgems
+	bundle update
+	cd driver/riverqueue-activerecord && bundle update
+	cd driver/riverqueue-sequel && bundle update


### PR DESCRIPTION
Add `make install` target so it's easy to install dependencies in the
main gem and all sub-gems. Change `make bundle-update` to just be `make
update` to fit with the new command, and to make the update version
easier to run (I can't think of anything else it'd potentially clash
with in the future, so I think it's okay to claim the shorter name).