### PR TITLE
Prepare release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2025-04-11
+
 ### Changed
 
 - `by_period` uniqueness is now based off a job's `scheduled_at` instead of the current time if it has a value. [PR #39](https://github.com/riverqueue/riverqueue-ruby/pull/39).
+
+## Fixed
+
+- Correct some mistakes in the readme that referenced `SimpleArgs` instead of `SortArgs`. [PR #44](https://github.com/riverqueue/riverqueue-ruby/pull/44).
 
 ## [0.8.0] - 2024-12-19
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    riverqueue (0.8.0)
+    riverqueue (0.9.0)
 
 PATH
   remote: driver/riverqueue-sequel
   specs:
-    riverqueue-sequel (0.8.0)
+    riverqueue-sequel (0.9.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 

--- a/driver/riverqueue-activerecord/Gemfile.lock
+++ b/driver/riverqueue-activerecord/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.8.0)
+    riverqueue (0.9.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-activerecord (0.8.0)
+    riverqueue-activerecord (0.9.0)
       activerecord (> 0, < 1000)
       activesupport (> 0, < 1000)
       pg (> 0, < 1000)

--- a/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
+++ b/driver/riverqueue-activerecord/riverqueue-activerecord.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-activerecord"
-  s.version = "0.8.0"
+  s.version = "0.9.0"
   s.summary = "ActiveRecord driver for the River Ruby gem."
   s.description = "ActiveRecord driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/driver/riverqueue-sequel/Gemfile.lock
+++ b/driver/riverqueue-sequel/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: ../..
   specs:
-    riverqueue (0.8.0)
+    riverqueue (0.9.0)
 
 PATH
   remote: .
   specs:
-    riverqueue-sequel (0.8.0)
+    riverqueue-sequel (0.9.0)
       pg (> 0, < 1000)
       sequel (> 0, < 1000)
 

--- a/driver/riverqueue-sequel/riverqueue-sequel.gemspec
+++ b/driver/riverqueue-sequel/riverqueue-sequel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue-sequel"
-  s.version = "0.8.0"
+  s.version = "0.9.0"
   s.summary = "Sequel driver for the River Ruby gem."
   s.description = "Sequel driver for the River Ruby gem. Use in conjunction with the riverqueue gem to insert jobs that are worked in Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]

--- a/riverqueue.gemspec
+++ b/riverqueue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "riverqueue"
-  s.version = "0.8.0"
+  s.version = "0.9.0"
   s.summary = "River is a fast job queue for Go."
   s.description = "River is a fast job queue for Go. Use this gem in conjunction with gems riverqueue-activerecord or riverqueue-sequel to insert jobs in Ruby which will be worked from Go."
   s.authors = ["Blake Gentry", "Brandur Leach"]


### PR DESCRIPTION
I just noticed that we've had an unreleased change sitting in `master`
since December since changes in this gem are pretty rare unfortunately.
Let's cut a release just so we can get that change (#39) finally shipped
out.