### PR TITLE
Fix ActiveRecord JSONB args

### DIFF
--- a/driver/riverqueue-activerecord/lib/driver.rb
+++ b/driver/riverqueue-activerecord/lib/driver.rb
@@ -91,7 +91,7 @@ module River::Driver
 
       River::JobRow.new(
         id: river_job.id,
-        args: deserialize_json(river_job.args),
+        args: river_job.args,
         attempt: river_job.attempt,
         attempted_at: river_job.attempted_at&.getutc,
         attempted_by: river_job.attempted_by,
@@ -153,7 +153,7 @@ module River::Driver
       [
         River::JobRow.new(
           id: river_job["id"],
-          args: deserialize_json(river_job["args"]),
+          args: river_job["args"],
           attempt: river_job["attempt"],
           attempted_at: river_job["attempted_at"]&.getutc,
           attempted_by: river_job["attempted_by"],
@@ -173,9 +173,6 @@ module River::Driver
         ),
         river_job["unique_skipped_as_duplicate"]
       ]
-    end
-    private def deserialize_json(value)
-      value.is_a?(String) ? JSON.parse(value) : value
     end
   end
 end

--- a/driver/riverqueue-activerecord/lib/driver.rb
+++ b/driver/riverqueue-activerecord/lib/driver.rb
@@ -71,7 +71,7 @@ module River::Driver
 
     private def insert_params_to_hash(insert_params)
       {
-        args: insert_params.encoded_args,
+        args: JSON.parse(insert_params.encoded_args),
         kind: insert_params.kind,
         max_attempts: insert_params.max_attempts,
         priority: insert_params.priority,
@@ -91,7 +91,7 @@ module River::Driver
 
       River::JobRow.new(
         id: river_job.id,
-        args: JSON.parse(river_job.args),
+        args: deserialize_json(river_job.args),
         attempt: river_job.attempt,
         attempted_at: river_job.attempted_at&.getutc,
         attempted_by: river_job.attempted_by,
@@ -153,7 +153,7 @@ module River::Driver
       [
         River::JobRow.new(
           id: river_job["id"],
-          args: JSON.parse(river_job["args"]),
+          args: deserialize_json(river_job["args"]),
           attempt: river_job["attempt"],
           attempted_at: river_job["attempted_at"]&.getutc,
           attempted_by: river_job["attempted_by"],
@@ -173,6 +173,9 @@ module River::Driver
         ),
         river_job["unique_skipped_as_duplicate"]
       ]
+    end
+    private def deserialize_json(value)
+      value.is_a?(String) ? JSON.parse(value) : value
     end
   end
 end

--- a/driver/riverqueue-activerecord/spec/driver_spec.rb
+++ b/driver/riverqueue-activerecord/spec/driver_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe River::Driver::ActiveRecord do
 
   it_behaves_like "driver shared examples"
 
+  describe "client inserts" do
+    it "persists args as a JSON object rather than a JSON string" do
+      insert_res = client.insert(SimpleArgs.new(job_num: 1))
+
+      row = ActiveRecord::Base.connection.exec_query(<<~SQL).first
+        SELECT args, jsonb_typeof(args) AS args_type
+        FROM river_job
+        WHERE id = #{insert_res.job.id}
+      SQL
+
+      expect(row["args_type"]).to eq("object")
+      expect(JSON.parse(row["args"])).to eq({"job_num" => 1})
+    end
+  end
+
   describe "#to_job_row_from_model" do
     it "converts a database record to `River::JobRow` with minimal properties" do
       river_job = River::Driver::ActiveRecord::RiverJob.create(

--- a/driver/riverqueue-activerecord/spec/driver_spec.rb
+++ b/driver/riverqueue-activerecord/spec/driver_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe River::Driver::ActiveRecord do
     it "converts a database record to `River::JobRow` with minimal properties" do
       river_job = River::Driver::ActiveRecord::RiverJob.create(
         id: 1,
-        args: %({"job_num":1}),
+        args: {"job_num" => 1},
         kind: "simple",
         max_attempts: River::MAX_ATTEMPTS_DEFAULT,
         priority: River::PRIORITY_DEFAULT,
@@ -71,7 +71,7 @@ RSpec.describe River::Driver::ActiveRecord do
         attempted_at: now,
         attempted_by: ["client1"],
         created_at: now,
-        args: %({"job_num":1}),
+        args: {"job_num" => 1},
         finalized_at: now,
         kind: "simple",
         max_attempts: River::MAX_ATTEMPTS_DEFAULT,
@@ -108,7 +108,7 @@ RSpec.describe River::Driver::ActiveRecord do
     it "with errors" do
       now = Time.now.utc
       river_job = River::Driver::ActiveRecord::RiverJob.create(
-        args: %({"job_num":1}),
+        args: {"job_num" => 1},
         errors: [JSON.dump(
           {
             at: now,
@@ -139,7 +139,7 @@ RSpec.describe River::Driver::ActiveRecord do
     it "converts a database record to `River::JobRow` with minimal properties" do
       res = River::Driver::ActiveRecord::RiverJob.insert({
         id: 1,
-        args: %({"job_num":1}),
+        args: {"job_num" => 1},
         kind: "simple",
         max_attempts: River::MAX_ATTEMPTS_DEFAULT
       }, returning: Arel.sql("*, false AS unique_skipped_as_duplicate"))
@@ -174,7 +174,7 @@ RSpec.describe River::Driver::ActiveRecord do
         attempted_at: now,
         attempted_by: ["client1"],
         created_at: now,
-        args: %({"job_num":1}),
+        args: {"job_num" => 1},
         finalized_at: now,
         kind: "simple",
         max_attempts: River::MAX_ATTEMPTS_DEFAULT,
@@ -212,7 +212,7 @@ RSpec.describe River::Driver::ActiveRecord do
     it "with errors" do
       now = Time.now.utc
       res = River::Driver::ActiveRecord::RiverJob.insert({
-        args: %({"job_num":1}),
+        args: {"job_num" => 1},
         errors: [JSON.dump(
           {
             at: now,

--- a/driver/riverqueue-sequel/spec/driver_spec.rb
+++ b/driver/riverqueue-sequel/spec/driver_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe River::Driver::Sequel do
 
   it_behaves_like "driver shared examples"
 
+  describe "client inserts" do
+    it "persists args as a JSON object rather than a JSON string" do
+      insert_res = client.insert(SimpleArgs.new(job_num: 1))
+
+      row = DB.fetch(<<~SQL, insert_res.job.id).first
+        SELECT args, jsonb_typeof(args) AS args_type
+        FROM river_job
+        WHERE id = ?
+      SQL
+
+      expect(row[:args_type]).to eq("object")
+      expect(row[:args].to_h).to eq({"job_num" => 1})
+    end
+  end
+
   describe "#to_job_row" do
     it "converts a database record to `River::JobRow` with minimal properties" do
       river_job = DB[:river_job].returning.insert_select({


### PR DESCRIPTION
The ActiveRecord driver stores `river_job.args` incorrectly for object-shaped job args.

Today the driver passes the already JSON-encoded args string directly into ActiveRecord. For a `jsonb` column, ActiveRecord serializes Ruby values to JSON on write, so passing a JSON string causes the payload to be encoded again. PostgreSQL ends up storing a JSON string whose contents are `{"job_num":1}` instead of storing a JSON object.

That breaks Go workers, which unmarshal job args directly into the worker args struct:

```
json: cannot unmarshal string into Go value of type ...Args
```

This PR is split into two commits:

1. Fix the write path by parsing the encoded args into a native Ruby value before insert, so ActiveRecord writes a proper JSONB object.
2. Remove the temporary read-side compatibility shim and require proper JSONB objects on read. ActiveRecord-specific fixtures are updated to insert valid rows.

I also added a sanity-check regression test for the Sequel driver to document that it does not have this issue.